### PR TITLE
Removing a pin to Sui version, using always latest instead

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -66,9 +66,6 @@ compatible (from the Sui Move point of view) chain, based on [`Suibase`][suibase
 
 You can download and install Suibase with `just suibase-setup`.
 
-> [!NOTE]
-> Our setup script pins localnet to a particular version in `~/suibase/workdirs/localnet/suibase.yaml`
-
 ### `PATH`
 
 Make sure `~/.local/bin` is in your `PATH`. Suibase requires this, as it installs its

--- a/justfile
+++ b/justfile
@@ -1,6 +1,5 @@
 python_version := "3.10"
 llama_version := "llama3.2:1b"
-sui_tag := "testnet-v1.28.3"
 
 [private]
 default:
@@ -97,12 +96,13 @@ suibase-setup:
         cd ~/suibase
         ./install
 
+        # Because Suibase does not support pagination of Github Sui's releases,
+        # we just use the latest release.
+        # While we could use 'force_tag' in the Suibase config, with the cadence
+        # of Sui releases this would break every now and then.
+        # Instead, we rely on the fact that the features we use should be stable
+        # and we don't _expect_ breaking changes.
         localnet create
-        # Pin Sui version to minimum supported by Suibase.
-        # This ought to match the talus package version as close as possible.
-        config=~/suibase/workdirs/localnet/suibase.yaml
-        echo '' >> $config
-        echo 'force_tag: "{{ sui_tag }}"' >> $config
         localnet update
     else
         echo ~/suibase exists


### PR DESCRIPTION
Because Suibase does not support pagination of Github releases, any pinned Sui version of testnet soon results in an error. We use the latest Sui tag instead to avoid this.